### PR TITLE
Add global auth context and refactor auth usage

### DIFF
--- a/src/components/auth/protected-route.tsx
+++ b/src/components/auth/protected-route.tsx
@@ -1,90 +1,22 @@
-import { useEffect, useState } from "react";
-import { Navigate, Outlet, useNavigate } from "react-router-dom";
-import { supabase } from "@/integrations/supabase/client";
+import { Navigate, Outlet } from "react-router-dom";
 import {
   useRegisterLoadingState,
   LoadingPriority,
 } from "@/context/app-loading-context";
-import LoadingScreen from "@/components/loading-screen";
+import { useAuth } from "@/context/auth-context";
 
 const ProtectedRoute = () => {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
-  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
-  const navigate = useNavigate();
+  const { session, isAuthLoading } = useAuth();
 
   // Register auth loading as HIGH priority - we can't do anything until auth is checked
-  useRegisterLoadingState(
-    "authentication",
-    isCheckingAuth,
-    LoadingPriority.HIGH
-  );
+  useRegisterLoadingState("authentication", isAuthLoading, LoadingPriority.HIGH);
 
-  useEffect(() => {
-    let mounted = true;
-
-    const checkAuth = async () => {
-      try {
-        // Get the current session
-        const {
-          data: { session },
-          error,
-        } = await supabase.auth.getSession();
-
-        if (error) {
-          console.error("Auth session error:", error);
-          if (mounted) {
-            setIsAuthenticated(false);
-            setIsCheckingAuth(false);
-          }
-          return;
-        }
-
-        if (mounted) {
-          setIsAuthenticated(!!session);
-          setIsCheckingAuth(false);
-        }
-      } catch (error) {
-        console.error("Auth check error:", error);
-        if (mounted) {
-          setIsAuthenticated(false);
-          setIsCheckingAuth(false);
-        }
-      }
-    };
-
-    // Set up auth state change listener
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
-      console.log("Auth state change in protected route:", event);
-
-      if (mounted) {
-        setIsAuthenticated(!!session);
-
-        if (event === "SIGNED_OUT") {
-          navigate("/auth");
-        }
-      }
-    });
-
-    // Initial auth check
-    checkAuth();
-
-    // Cleanup
-    return () => {
-      mounted = false;
-      subscription.unsubscribe();
-    };
-  }, [navigate]);
-
-  // We don't need to manually render a loading screen anymore since the app-level
-  // loading screen will show automatically while isCheckingAuth is true
-  if (isCheckingAuth) {
-    // Return empty fragment - the global loading state will handle rendering a loading screen
+  if (isAuthLoading) {
+    // Global loading screen will handle UI
     return <></>;
   }
 
-  return isAuthenticated ? <Outlet /> : <Navigate to="/auth" />;
+  return session ? <Outlet /> : <Navigate to="/auth" />;
 };
 
 export default ProtectedRoute;

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import { Session } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
+import { useRegisterLoadingState, LoadingPriority } from "@/context/app-loading-context";
+
+interface AuthContextType {
+  session: Session | null;
+  isAuthLoading: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+  // register global loading state
+  useRegisterLoadingState("authentication", isAuthLoading, LoadingPriority.HIGH);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const getInitialSession = async () => {
+      const { data, error } = await supabase.auth.getSession();
+      if (!mounted) return;
+      if (error) {
+        console.error("Auth session error:", error);
+      }
+      setSession(data.session);
+      setIsAuthLoading(false);
+    };
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (mounted) {
+        setSession(session);
+      }
+    });
+
+    getInitialSession();
+
+    return () => {
+      mounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ session, isAuthLoading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};
+

--- a/src/context/workspace-context.tsx
+++ b/src/context/workspace-context.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
 import { LoadingPriority, useAppLoading } from "./app-loading-context";
 import { useApiLoading } from "@/hooks/use-api-loading";
+import { useAuth } from "./auth-context";
 
 interface Workspace {
   id: string;
@@ -49,6 +50,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [creationError, setCreationError] = useState<string | null>(null);
   const { toast } = useToast();
   const navigate = useNavigate();
+  const { session } = useAuth();
 
   // Use register loading state directly from app-loading-context
   // This is safe because it properly handles hooks at the component level
@@ -75,9 +77,6 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       console.log(
         `Fetching workspaces... (attempt ${retryCount + 1}/${maxRetries + 1})`
       );
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
 
       if (!session) {
         console.log("No session found, waiting for auth...");
@@ -228,10 +227,6 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   ): Promise<Workspace | null> => {
     try {
       setCreationError(null);
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-
       if (!session) return null;
 
       // Use the custom workspace name if provided
@@ -339,10 +334,6 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
 
   const switchWorkspace = async (workspace: Workspace) => {
     try {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-
       if (!session) return;
 
       // Update the current workspace in the profile
@@ -376,75 +367,24 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   // Custom hook to check if workspace is ready
   const isWorkspaceReady = Boolean(activeWorkspace?.id || previousWorkspace?.id);
 
-  // Initialize workspace loading when the app starts
+  // Clear redirect attempts on mount
   useEffect(() => {
-    // Clear any previous redirect attempts when mounting
     localStorage.removeItem("workspaceRedirectAttempt");
+  }, []);
 
-    // Keep track of last auth event time to prevent duplicates
-    let lastAuthEventTime = 0;
-    const MIN_EVENT_INTERVAL = 2000; // 2 seconds minimum between events
-    let isAuthenticated = !!activeWorkspace; // Initialize based on cached workspace
+  useEffect(() => {
+    if (session) {
+      fetchWorkspaces();
+    } else {
+      localStorage.removeItem("cachedWorkspace");
+      setPreviousWorkspace(null);
+      setActiveWorkspace(null);
+      setWorkspaces([]);
+      setHasLoadedWorkspaceOnce(false);
+      setIsLoading(false);
+    }
+  }, [session]);
 
-    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
-      const now = Date.now();
-      console.log(`[Auth Debug] Auth event: ${event}, session: ${!!session}, time since last: ${now - lastAuthEventTime}ms, isAuthenticated: ${isAuthenticated}`);
-
-      if (event === "SIGNED_IN") {
-        if (session && (now - lastAuthEventTime > MIN_EVENT_INTERVAL || !isAuthenticated)) {
-          console.log("User signed in (genuine sign-in event or initial load), fetching workspaces...");
-          isAuthenticated = true;
-          fetchWorkspaces();
-        } else if (session && isAuthenticated) {
-          console.log("Ignoring likely token refresh or duplicate SIGNED_IN event (already authenticated).");
-        } else if (!session) {
-          console.log("SIGNED_IN event but no session, likely an error or race condition.");
-        }
-      } else if (event === "TOKEN_REFRESHED") {
-        console.log("Token refreshed - maintaining current workspace state. Session:", !!session);
-        // Ensure isAuthenticated is true if we have a session
-        if (session) isAuthenticated = true;
-        // Do NOT fetch workspaces again
-      } else if (event === "SIGNED_OUT") {
-        console.log("User signed out, clearing workspace state");
-        isAuthenticated = false;
-        localStorage.removeItem('cachedWorkspace');
-        setPreviousWorkspace(null);
-        setActiveWorkspace(null);
-        setWorkspaces([]);
-        setHasLoadedWorkspaceOnce(false); // Reset this on sign out
-      }
-      lastAuthEventTime = now;
-    });
-
-    // Initial fetch - only if not already loading and no active workspace from cache
-    // The `isLoading` check here might be tricky due to initial state `true`.
-    // `fetchWorkspaces` itself sets `isLoading = true` at the start.
-    // The primary trigger for initial fetch should be the SIGNED_IN event.
-    // However, we also need to handle the case where a session might already exist when the provider mounts.
-    // Let's check session on mount and fetch if a session exists and no workspace is cached,
-    // or if the auth listener fires SIGNED_IN.
-    const checkSessionAndFetch = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      if (session && !activeWorkspace) { // If session exists and no workspace from cache
-        console.log("Session exists on mount, no cached workspace, fetching workspaces...");
-        isAuthenticated = true; // Assume authenticated if session exists
-        fetchWorkspaces();
-      } else if (activeWorkspace) { // If workspace from cache
-        console.log("Using cached workspace initially.");
-        setHasLoadedWorkspaceOnce(true);
-        setIsLoading(false);
-      } else { // No session, no cache
-        setIsLoading(false); // Not loading if no session and no cache
-      }
-    };
-    checkSessionAndFetch();
-
-
-    return () => {
-      authListener?.subscription.unsubscribe();
-    };
-  }, []); // Keep empty dependency array for single setup/cleanup
 
   const value = {
     currentWorkspace: activeWorkspace || previousWorkspace, // Use fallback

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import { Toaster } from "./components/ui/toaster";
 import { WorkspaceProvider } from "./context/workspace-context";
 import { ThemeProvider } from "./context/theme-context";
 import { AppLoadingProvider } from "./context/app-loading-context";
+import { AuthProvider } from "./context/auth-context";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -37,10 +38,12 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
         >
           <ThemeProvider>
             <AppLoadingProvider>
-              <WorkspaceProvider>
-                <App />
-                <Toaster />
-              </WorkspaceProvider>
+              <AuthProvider>
+                <WorkspaceProvider>
+                  <App />
+                  <Toaster />
+                </WorkspaceProvider>
+              </AuthProvider>
             </AppLoadingProvider>
           </ThemeProvider>
         </NextThemesProvider>

--- a/src/pages/auth/index.tsx
+++ b/src/pages/auth/index.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/context/auth-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -19,30 +20,21 @@ const AuthPage = () => {
   const [authError, setAuthError] = useState<string | null>(null);
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { session, isAuthLoading } = useAuth();
 
   useEffect(() => {
     // Check the mode param from URL
-    const mode = searchParams.get('mode');
-    setIsSignUp(mode === 'signup');
-    
+    const mode = searchParams.get("mode");
+    setIsSignUp(mode === "signup");
+
     // Clear previous error when switching modes
     setAuthError(null);
 
-    // Check if there's an existing session
-    const checkSession = async () => {
-      try {
-        const { data } = await supabase.auth.getSession();
-        if (data.session) {
-          // If already logged in, redirect to dashboard
-          navigate("/dashboard/agents");
-        }
-      } catch (error) {
-        console.error("Session check error:", error);
-      }
-    };
-    
-    checkSession();
-  }, [searchParams, navigate]);
+    // If user already has a session after loading, redirect
+    if (!isAuthLoading && session) {
+      navigate("/dashboard/agents");
+    }
+  }, [searchParams, navigate, session, isAuthLoading]);
 
   const handleToggleMode = () => {
     setAuthError(null); // Clear errors on mode switch

--- a/src/pages/onboarding/hooks/use-onboarding.ts
+++ b/src/pages/onboarding/hooks/use-onboarding.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/context/auth-context";
 import { useToast } from "@/hooks/use-toast";
 import { steps } from "../components/steps";
 import type { OnboardingData } from "../types";
@@ -25,15 +26,21 @@ export const useOnboarding = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const { createDefaultWorkspace, isWorkspaceReady, hasLoadedWorkspaceOnce } = useWorkspace();
+  const { session, isAuthLoading } = useAuth();
 
   useEffect(() => {
-    checkSession();
-  }, []);
+    if (!isAuthLoading) {
+      if (!session) {
+        navigate("/auth");
+      } else {
+        checkSession();
+      }
+    }
+  }, [isAuthLoading, session]);
 
   const checkSession = async () => {
     try {
       setCheckingSession(true);
-      const { data: { session } } = await supabase.auth.getSession();
       if (!session) {
         navigate("/auth");
         return;
@@ -106,8 +113,12 @@ export const useOnboarding = () => {
   const completeOnboarding = async () => {
     setIsCompleting(true);
     setError(null);
-    const { data: { session } } = await supabase.auth.getSession();
-    
+    if (!session?.user) {
+      navigate("/auth");
+      setIsCompleting(false);
+      return;
+    }
+
     if (session?.user) {
       try {
         console.log("Starting onboarding completion for user:", session.user.id);


### PR DESCRIPTION
## Summary
- create AuthProvider with `useAuth` hook
- wrap `<App>` with AuthProvider
- simplify ProtectedRoute to use `useAuth`
- redirect from AuthPage after session is loaded
- update onboarding hook and workspace context to use the new auth state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684605744b5c832bb17556ede35af463