### PR TITLE
Implement centralized auth and workspace loading

### DIFF
--- a/src/components/auth/protected-route.tsx
+++ b/src/components/auth/protected-route.tsx
@@ -1,90 +1,17 @@
-import { useEffect, useState } from "react";
-import { Navigate, Outlet, useNavigate } from "react-router-dom";
-import { supabase } from "@/integrations/supabase/client";
-import {
-  useRegisterLoadingState,
-  LoadingPriority,
-} from "@/context/app-loading-context";
-import LoadingScreen from "@/components/loading-screen";
+import { Navigate, Outlet } from "react-router-dom";
+import { useRegisterLoadingState, LoadingPriority } from "@/context/app-loading-context";
+import { useAuth } from "@/context/auth-context";
 
 const ProtectedRoute = () => {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
-  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
-  const navigate = useNavigate();
+  const { session, isAuthLoading } = useAuth();
 
-  // Register auth loading as HIGH priority - we can't do anything until auth is checked
-  useRegisterLoadingState(
-    "authentication",
-    isCheckingAuth,
-    LoadingPriority.HIGH
-  );
+  useRegisterLoadingState("authentication", isAuthLoading, LoadingPriority.HIGH);
 
-  useEffect(() => {
-    let mounted = true;
-
-    const checkAuth = async () => {
-      try {
-        // Get the current session
-        const {
-          data: { session },
-          error,
-        } = await supabase.auth.getSession();
-
-        if (error) {
-          console.error("Auth session error:", error);
-          if (mounted) {
-            setIsAuthenticated(false);
-            setIsCheckingAuth(false);
-          }
-          return;
-        }
-
-        if (mounted) {
-          setIsAuthenticated(!!session);
-          setIsCheckingAuth(false);
-        }
-      } catch (error) {
-        console.error("Auth check error:", error);
-        if (mounted) {
-          setIsAuthenticated(false);
-          setIsCheckingAuth(false);
-        }
-      }
-    };
-
-    // Set up auth state change listener
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
-      console.log("Auth state change in protected route:", event);
-
-      if (mounted) {
-        setIsAuthenticated(!!session);
-
-        if (event === "SIGNED_OUT") {
-          navigate("/auth");
-        }
-      }
-    });
-
-    // Initial auth check
-    checkAuth();
-
-    // Cleanup
-    return () => {
-      mounted = false;
-      subscription.unsubscribe();
-    };
-  }, [navigate]);
-
-  // We don't need to manually render a loading screen anymore since the app-level
-  // loading screen will show automatically while isCheckingAuth is true
-  if (isCheckingAuth) {
-    // Return empty fragment - the global loading state will handle rendering a loading screen
+  if (isAuthLoading) {
     return <></>;
   }
 
-  return isAuthenticated ? <Outlet /> : <Navigate to="/auth" />;
+  return session ? <Outlet /> : <Navigate to="/auth" />;
 };
 
 export default ProtectedRoute;

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { Session } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase/client';
+
+interface AuthContextType {
+  session: Session | null;
+  isAuthLoading: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const getInitialSession = async () => {
+      const { data } = await supabase.auth.getSession();
+      if (mounted) {
+        setSession(data.session);
+        setIsAuthLoading(false);
+      }
+    };
+
+    getInitialSession();
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_, newSession) => {
+      if (mounted) setSession(newSession);
+    });
+
+    return () => {
+      mounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ session, isAuthLoading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/src/context/workspace-context.tsx
+++ b/src/context/workspace-context.tsx
@@ -4,13 +4,14 @@ import React, {
   useState,
   useEffect,
   ReactNode,
-  useCallback,
 } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
 import { LoadingPriority, useAppLoading } from "./app-loading-context";
-import { useApiLoading } from "@/hooks/use-api-loading";
+import { useWorkspace as useWorkspaceQuery } from "@/hooks/use-workspace";
+import { useAuth } from "./auth-context";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface Workspace {
   id: string;
@@ -37,6 +38,7 @@ const WorkspaceContext = createContext<WorkspaceContextType | undefined>(
   undefined
 );
 
+
 export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const cachedWorkspace = localStorage.getItem('cachedWorkspace');
   const [activeWorkspace, setActiveWorkspace] = useState<Workspace | null>(
@@ -44,182 +46,44 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   );
   const [previousWorkspace, setPreviousWorkspace] = useState<Workspace | null>(null);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasLoadedWorkspaceOnce, setHasLoadedWorkspaceOnce] = useState(false); // New state
+  const [hasLoadedWorkspaceOnce, setHasLoadedWorkspaceOnce] = useState(false);
   const [creationError, setCreationError] = useState<string | null>(null);
+  const { registerLoadingState, unregisterLoadingState } = useAppLoading();
   const { toast } = useToast();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { session } = useAuth();
 
-  // Use register loading state directly from app-loading-context
-  // This is safe because it properly handles hooks at the component level
-  const { registerLoadingState, unregisterLoadingState } = useAppLoading();
+  const { data, isLoading } = useWorkspaceQuery();
 
-  // Register the workspace loading state
   useEffect(() => {
-    // Register the loading state with dynamic priority
     const priority = hasLoadedWorkspaceOnce ? LoadingPriority.MEDIUM : LoadingPriority.HIGH;
-    registerLoadingState("workspace", isLoading, priority);
-
-    // Log the current loading state for debugging
-    console.log(`Workspace loading state: ${isLoading ? "loading" : "loaded"} with priority: ${priority}`);
-
-    // Clean up on unmount
-    return () => {
-      unregisterLoadingState("workspace");
-    };
+    registerLoadingState('workspace', isLoading, priority);
+    return () => unregisterLoadingState('workspace');
   }, [isLoading, registerLoadingState, unregisterLoadingState, hasLoadedWorkspaceOnce]);
 
-  const fetchWorkspaces = async (retryCount = 0, maxRetries = 3) => {
-    try {
-      setIsLoading(true);
-      console.log(
-        `Fetching workspaces... (attempt ${retryCount + 1}/${maxRetries + 1})`
-      );
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-
-      if (!session) {
-        console.log("No session found, waiting for auth...");
-
-        // If no session but we haven't reached max retries, retry after delay
-        if (retryCount < maxRetries) {
-          setTimeout(() => {
-            fetchWorkspaces(retryCount + 1, maxRetries);
-          }, 1000 * (retryCount + 1)); // Exponential backoff
-          return;
-        }
-
-        setIsLoading(false);
-        return;
-      }
-
-      // Get all workspaces where user is a member - using the simplified RLS policy
-      const { data: memberData, error: memberError } = await supabase
-        .from("workspace_members")
-        .select("workspace_id")
-        .eq("user_id", session.user.id);
-
-      if (memberError) {
-        console.error("Error fetching workspace members:", memberError);
-        setIsLoading(false);
-        return;
-      }
-
-      if (!memberData || memberData.length === 0) {
-        console.log("No workspaces found, redirecting to onboarding");
-        setIsLoading(false);
-
-        // Ensure we're not in a loop - use local storage to prevent infinite redirects
-        const redirectAttempt = localStorage.getItem(
-          "workspaceRedirectAttempt"
-        );
-        const now = Date.now();
-
-        if (!redirectAttempt || now - parseInt(redirectAttempt) > 30000) {
-          // 30 seconds threshold
-          localStorage.setItem("workspaceRedirectAttempt", now.toString());
-          navigate("/onboarding");
-        }
-        return;
-      }
-
-      const workspaceIds = memberData.map((m) => m.workspace_id);
-
-      // Get workspace details
-      const { data: workspacesData, error: workspacesError } = await supabase
-        .from("workspaces")
-        .select("*")
-        .in("id", workspaceIds);
-
-      if (workspacesError) {
-        console.error("Error fetching workspaces:", workspacesError);
-
-        // Retry if we haven't reached max retries
-        if (retryCount < maxRetries) {
-          setTimeout(() => {
-            fetchWorkspaces(retryCount + 1, maxRetries);
-          }, 1000 * (retryCount + 1)); // Exponential backoff
-          return;
-        }
-
-        throw workspacesError;
-      }
-
-      // Get current workspace from profile
-      const { data: profile, error: profileError } = await supabase
-        .from("profiles")
-        .select("current_workspace_id")
-        .eq("id", session.user.id)
-        .maybeSingle();
-
-      if (profileError && profileError.code !== "PGRST116") {
-        console.error("Error fetching profile:", profileError);
-        throw profileError;
-      }
-
-      const mappedWorkspaces = workspacesData.map((w) => ({
-        id: w.id,
-        name: w.name,
-        icon: w.icon || "building",
-      }));
-
-      console.log("Fetched workspaces:", mappedWorkspaces);
-      setWorkspaces(mappedWorkspaces);
-
-      if (profile?.current_workspace_id) {
-        const current = mappedWorkspaces.find(
-          (w) => w.id === profile.current_workspace_id
-        );
-        if (current) {
-          setPreviousWorkspace(activeWorkspace);
-          setActiveWorkspace(current);
-          if (current) {
-            setHasLoadedWorkspaceOnce(true); // Set flag
-            localStorage.setItem('cachedWorkspace', JSON.stringify(current)); // Cache workspace
-          }
-        } else if (mappedWorkspaces.length > 0) {
-          setPreviousWorkspace(activeWorkspace);
-          setActiveWorkspace(mappedWorkspaces[0]);
-          if (mappedWorkspaces[0]) {
-            setHasLoadedWorkspaceOnce(true); // Set flag
-            localStorage.setItem('cachedWorkspace', JSON.stringify(mappedWorkspaces[0])); // Cache workspace
-          }
-          // Update the current workspace if it's not set
-          await supabase
-            .from("profiles")
-            .update({ current_workspace_id: mappedWorkspaces[0].id })
-            .eq("id", session.user.id);
-        }
-      } else if (mappedWorkspaces.length > 0) {
+  useEffect(() => {
+    if (data) {
+      setWorkspaces(data.workspaces);
+      if (data.current) {
         setPreviousWorkspace(activeWorkspace);
-        setActiveWorkspace(mappedWorkspaces[0]);
-        if (mappedWorkspaces[0]) {
-          setHasLoadedWorkspaceOnce(true); // Set flag
-          localStorage.setItem('cachedWorkspace', JSON.stringify(mappedWorkspaces[0])); // Cache workspace
-        }
-        // Set the first workspace as current if none is set
-        await supabase
-          .from("profiles")
-          .update({ current_workspace_id: mappedWorkspaces[0].id })
-          .eq("id", session.user.id);
+        setActiveWorkspace(data.current);
+        localStorage.setItem('cachedWorkspace', JSON.stringify(data.current));
+        if (!hasLoadedWorkspaceOnce) setHasLoadedWorkspaceOnce(true);
+      } else if (data.workspaces.length === 0 && session) {
+        navigate('/onboarding');
       }
-    } catch (error) {
-      console.error("Error fetching workspaces:", error);
-
-      // Retry if we haven't reached max retries
-      if (retryCount < maxRetries) {
-        const retryDelay = 1000 * (retryCount + 1); // Exponential backoff
-        console.log(`Retrying workspace fetch in ${retryDelay}ms...`);
-
-        setTimeout(() => {
-          fetchWorkspaces(retryCount + 1, maxRetries);
-        }, retryDelay);
-        return;
-      }
-    } finally {
-      setIsLoading(false);
     }
+    if (!session) {
+      setPreviousWorkspace(null);
+      setActiveWorkspace(null);
+      setWorkspaces([]);
+      setHasLoadedWorkspaceOnce(false);
+    }
+  }, [data, session, navigate, activeWorkspace, hasLoadedWorkspaceOnce]);
+
+  const refreshWorkspaces = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['workspace'] });
   };
 
   const createDefaultWorkspace = async (
@@ -228,247 +92,99 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   ): Promise<Workspace | null> => {
     try {
       setCreationError(null);
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-
       if (!session) return null;
 
-      // Use the custom workspace name if provided
       let workspaceName: string;
-
       if (customWorkspaceName) {
         workspaceName = customWorkspaceName;
       } else {
-        // Generate a default workspace name based on the user's email or user metadata
-        workspaceName = "My Workspace";
-
+        workspaceName = 'My Workspace';
         try {
-          // First try to get the name from the user metadata
           const { data: userMeta } = await supabase.auth.getUser();
           const firstName = userMeta?.user?.user_metadata?.firstName;
-          const lastName = userMeta?.user?.user_metadata?.lastName;
-
           if (firstName) {
             workspaceName = `${firstName}'s Workspace`;
           } else {
-            // Fall back to using email
-            const email = session.user.email || "";
-            const username = email.split("@")[0];
+            const email = session.user.email || '';
+            const username = email.split('@')[0];
             workspaceName = `${username}'s Workspace`;
           }
-        } catch (error) {
-          console.error("Error getting user metadata:", error);
-          // Continue with the default name
+        } catch {
+          /* ignore */
         }
       }
 
-      // Use custom icon if provided
-      const workspaceIcon = customIcon || "building";
+      const workspaceIcon = customIcon || 'building';
 
-      console.log("Creating workspace:", workspaceName);
-
-      // Create the workspace with the user as owner
-      // The database trigger will automatically add the user as a member
       const { data: workspace, error: workspaceError } = await supabase
-        .from("workspaces")
-        .insert({
-          name: workspaceName,
-          icon: workspaceIcon,
-          owner_id: session.user.id,
-        })
+        .from('workspaces')
+        .insert({ name: workspaceName, icon: workspaceIcon, owner_id: session.user.id })
         .select()
         .single();
-
       if (workspaceError) {
-        console.error("Workspace creation error:", workspaceError);
         setCreationError(workspaceError.message);
-
-        toast({
-          variant: "destructive",
-          title: "Error",
-          description:
-            "Failed to create default workspace. Please try again later.",
-        });
-
+        toast({ variant: 'destructive', title: 'Error', description: 'Failed to create workspace.' });
         throw workspaceError;
       }
 
-      console.log("Workspace created:", workspace);
-
-      // Set as current workspace
-      const { error: profileError } = await supabase
-        .from("profiles")
+      await supabase
+        .from('profiles')
         .update({ current_workspace_id: workspace.id })
-        .eq("id", session.user.id);
+        .eq('id', session.user.id);
 
-      if (profileError) {
-        console.error("Profile update error:", profileError);
-        // Continue anyway as we've at least created the workspace
-      } else {
-        console.log("Profile updated with current workspace");
-      }
-
-      // Create the workspace object for the state
-      const newWorkspace = {
-        id: workspace.id,
-        name: workspace.name,
-        icon: workspace.icon || "building",
-      };
-
-      // Update local state
+      const newWorkspace = { id: workspace.id, name: workspace.name, icon: workspace.icon || 'building' };
       setWorkspaces((prev) => [...prev, newWorkspace]);
       setPreviousWorkspace(activeWorkspace);
       setActiveWorkspace(newWorkspace);
-      if (newWorkspace) {
-        localStorage.setItem('cachedWorkspace', JSON.stringify(newWorkspace)); // Cache new workspace
-      }
-
-      toast({
-        title: "Workspace created",
-        description: `Workspace "${workspaceName}" created`,
-      });
-
+      localStorage.setItem('cachedWorkspace', JSON.stringify(newWorkspace));
+      toast({ title: 'Workspace created', description: `Workspace "${workspaceName}" created` });
+      await refreshWorkspaces();
       return newWorkspace;
     } catch (error: any) {
-      console.error("Error creating default workspace:", error);
-      setCreationError(error.message || "Unknown error");
+      setCreationError(error.message || 'Unknown error');
       return null;
     }
   };
 
   const switchWorkspace = async (workspace: Workspace) => {
     try {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-
       if (!session) return;
-
-      // Update the current workspace in the profile
       const { error } = await supabase
-        .from("profiles")
+        .from('profiles')
         .update({ current_workspace_id: workspace.id })
-        .eq("id", session.user.id);
-
+        .eq('id', session.user.id);
       if (error) throw error;
-
       setPreviousWorkspace(activeWorkspace);
       setActiveWorkspace(workspace);
-      if (workspace) {
-        localStorage.setItem('cachedWorkspace', JSON.stringify(workspace)); // Cache switched workspace
-      }
-
-      toast({
-        title: "Workspace switched",
-        description: `Switched to ${workspace.name}`,
-      });
+      localStorage.setItem('cachedWorkspace', JSON.stringify(workspace));
+      toast({ title: 'Workspace switched', description: `Switched to ${workspace.name}` });
+      await refreshWorkspaces();
     } catch (error) {
-      console.error("Error switching workspace:", error);
-      toast({
-        variant: "destructive",
-        title: "Error",
-        description: "Failed to switch workspace",
-      });
+      toast({ variant: 'destructive', title: 'Error', description: 'Failed to switch workspace' });
     }
   };
 
-  // Custom hook to check if workspace is ready
   const isWorkspaceReady = Boolean(activeWorkspace?.id || previousWorkspace?.id);
 
-  // Initialize workspace loading when the app starts
-  useEffect(() => {
-    // Clear any previous redirect attempts when mounting
-    localStorage.removeItem("workspaceRedirectAttempt");
-
-    // Keep track of last auth event time to prevent duplicates
-    let lastAuthEventTime = 0;
-    const MIN_EVENT_INTERVAL = 2000; // 2 seconds minimum between events
-    let isAuthenticated = !!activeWorkspace; // Initialize based on cached workspace
-
-    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
-      const now = Date.now();
-      console.log(`[Auth Debug] Auth event: ${event}, session: ${!!session}, time since last: ${now - lastAuthEventTime}ms, isAuthenticated: ${isAuthenticated}`);
-
-      if (event === "SIGNED_IN") {
-        if (session && (now - lastAuthEventTime > MIN_EVENT_INTERVAL || !isAuthenticated)) {
-          console.log("User signed in (genuine sign-in event or initial load), fetching workspaces...");
-          isAuthenticated = true;
-          fetchWorkspaces();
-        } else if (session && isAuthenticated) {
-          console.log("Ignoring likely token refresh or duplicate SIGNED_IN event (already authenticated).");
-        } else if (!session) {
-          console.log("SIGNED_IN event but no session, likely an error or race condition.");
-        }
-      } else if (event === "TOKEN_REFRESHED") {
-        console.log("Token refreshed - maintaining current workspace state. Session:", !!session);
-        // Ensure isAuthenticated is true if we have a session
-        if (session) isAuthenticated = true;
-        // Do NOT fetch workspaces again
-      } else if (event === "SIGNED_OUT") {
-        console.log("User signed out, clearing workspace state");
-        isAuthenticated = false;
-        localStorage.removeItem('cachedWorkspace');
-        setPreviousWorkspace(null);
-        setActiveWorkspace(null);
-        setWorkspaces([]);
-        setHasLoadedWorkspaceOnce(false); // Reset this on sign out
-      }
-      lastAuthEventTime = now;
-    });
-
-    // Initial fetch - only if not already loading and no active workspace from cache
-    // The `isLoading` check here might be tricky due to initial state `true`.
-    // `fetchWorkspaces` itself sets `isLoading = true` at the start.
-    // The primary trigger for initial fetch should be the SIGNED_IN event.
-    // However, we also need to handle the case where a session might already exist when the provider mounts.
-    // Let's check session on mount and fetch if a session exists and no workspace is cached,
-    // or if the auth listener fires SIGNED_IN.
-    const checkSessionAndFetch = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      if (session && !activeWorkspace) { // If session exists and no workspace from cache
-        console.log("Session exists on mount, no cached workspace, fetching workspaces...");
-        isAuthenticated = true; // Assume authenticated if session exists
-        fetchWorkspaces();
-      } else if (activeWorkspace) { // If workspace from cache
-        console.log("Using cached workspace initially.");
-        setHasLoadedWorkspaceOnce(true);
-        setIsLoading(false);
-      } else { // No session, no cache
-        setIsLoading(false); // Not loading if no session and no cache
-      }
-    };
-    checkSessionAndFetch();
-
-
-    return () => {
-      authListener?.subscription.unsubscribe();
-    };
-  }, []); // Keep empty dependency array for single setup/cleanup
-
   const value = {
-    currentWorkspace: activeWorkspace || previousWorkspace, // Use fallback
+    currentWorkspace: activeWorkspace || previousWorkspace,
     workspaces,
     isLoading,
     isWorkspaceReady,
-    hasLoadedWorkspaceOnce, // Expose new flag
+    hasLoadedWorkspaceOnce,
     switchWorkspace,
-    refreshWorkspaces: useCallback(() => fetchWorkspaces(0, 3), []),
+    refreshWorkspaces,
     createDefaultWorkspace,
     creationError,
   };
 
-  return (
-    <WorkspaceContext.Provider value={value}>
-      {children}
-    </WorkspaceContext.Provider>
-  );
+  return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
 }
 
 export const useWorkspace = () => {
   const context = useContext(WorkspaceContext);
   if (context === undefined) {
-    throw new Error("useWorkspace must be used within a WorkspaceProvider");
+    throw new Error('useWorkspace must be used within a WorkspaceProvider');
   }
   return context;
 };

--- a/src/hooks/use-workspace.ts
+++ b/src/hooks/use-workspace.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/context/auth-context';
+
+export interface Workspace {
+  id: string;
+  name: string;
+  icon: string;
+}
+
+export function useWorkspace() {
+  const { session } = useAuth();
+
+  return useQuery({
+    queryKey: ['workspace', session?.user.id],
+    enabled: !!session,
+    retry: 3,
+    queryFn: async () => {
+      if (!session) return { current: null as Workspace | null, workspaces: [] as Workspace[] };
+
+      const { data: memberData, error: memberError } = await supabase
+        .from('workspace_members')
+        .select('workspace_id')
+        .eq('user_id', session.user.id);
+      if (memberError) throw memberError;
+
+      if (!memberData || memberData.length === 0) {
+        return { current: null, workspaces: [] };
+      }
+
+      const workspaceIds = memberData.map((m) => m.workspace_id);
+      const { data: workspacesData, error: workspacesError } = await supabase
+        .from('workspaces')
+        .select('*')
+        .in('id', workspaceIds);
+      if (workspacesError) throw workspacesError;
+
+      const mapped = workspacesData.map((w) => ({
+        id: w.id,
+        name: w.name,
+        icon: w.icon || 'building',
+      }));
+
+      const { data: profile, error: profileError } = await supabase
+        .from('profiles')
+        .select('current_workspace_id')
+        .eq('id', session.user.id)
+        .maybeSingle();
+      if (profileError && profileError.code !== 'PGRST116') throw profileError;
+
+      const current =
+        mapped.find((w) => w.id === profile?.current_workspace_id) || mapped[0] || null;
+
+      return { current, workspaces: mapped };
+    },
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import "./styles/theme-styles.css";
 import "./styles/lightning-effects.css";
 import { Toaster } from "./components/ui/toaster";
 import { WorkspaceProvider } from "./context/workspace-context";
+import { AuthProvider } from "./context/auth-context";
 import { ThemeProvider } from "./context/theme-context";
 import { AppLoadingProvider } from "./context/app-loading-context";
 
@@ -37,10 +38,12 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
         >
           <ThemeProvider>
             <AppLoadingProvider>
-              <WorkspaceProvider>
-                <App />
-                <Toaster />
-              </WorkspaceProvider>
+              <AuthProvider>
+                <WorkspaceProvider>
+                  <App />
+                  <Toaster />
+                </WorkspaceProvider>
+              </AuthProvider>
             </AppLoadingProvider>
           </ThemeProvider>
         </NextThemesProvider>

--- a/src/pages/auth/index.tsx
+++ b/src/pages/auth/index.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/context/auth-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,29 +21,18 @@ const AuthPage = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
 
+  const { session } = useAuth();
+
   useEffect(() => {
-    // Check the mode param from URL
     const mode = searchParams.get('mode');
     setIsSignUp(mode === 'signup');
-    
-    // Clear previous error when switching modes
+
     setAuthError(null);
 
-    // Check if there's an existing session
-    const checkSession = async () => {
-      try {
-        const { data } = await supabase.auth.getSession();
-        if (data.session) {
-          // If already logged in, redirect to dashboard
-          navigate("/dashboard/agents");
-        }
-      } catch (error) {
-        console.error("Session check error:", error);
-      }
-    };
-    
-    checkSession();
-  }, [searchParams, navigate]);
+    if (session) {
+      navigate("/dashboard/agents");
+    }
+  }, [searchParams, navigate, session]);
 
   const handleToggleMode = () => {
     setAuthError(null); // Clear errors on mode switch


### PR DESCRIPTION
## Summary
- add AuthProvider context to track session via `onAuthStateChange`
- fetch workspace data with new `useWorkspace` React Query hook
- simplify workspace context to use the query hook
- update ProtectedRoute and auth page to rely on AuthProvider
- wrap app providers with AuthProvider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845ff9496e0832b9de305cc65e13ae6